### PR TITLE
Add support for monolog ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=8.0.0",
-        "monolog/monolog": "^1.17|^2.0"
+        "monolog/monolog": "^1.17|^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
@pmccarren hope you're doing well!

I'm still a big fan of doing request based logging and love this package.

I'm upgrading my project to Laravel 10 and this package is preventing the install from completing.

<img width="943" alt="image" src="https://github.com/cumulati/monolog-context/assets/3410152/5c8570dd-7822-4641-9958-a36aeec6380f">

I added monolog 3.0 as an option to the composer.json file. From what I can tell the package is still working fine and example.php script does not throw any errors.

Here is a link to what changed with monolog 3.0: https://github.com/Seldaek/monolog/blob/main/UPGRADE.md#300

Thanks!